### PR TITLE
chore: Repo uses master not main

### DIFF
--- a/.github/workflows/pr-label-checker.yml
+++ b/.github/workflows/pr-label-checker.yml
@@ -2,7 +2,7 @@ name: PR Label - Checker
 on:
   pull_request:
     branches:
-      - main
+      - master
     types:
       - reopened
       - labeled

--- a/.github/workflows/request-pr-label.yml
+++ b/.github/workflows/request-pr-label.yml
@@ -2,7 +2,7 @@ name: 'PR Open: Request Label'
 on:
   pull_request:
     branches:
-      - main
+      - master
     types:
       - opened
 jobs:

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -6,7 +6,7 @@ name: Tag on Merge
 on:
   pull_request:
     branches:
-      - main
+      - master
     types:
       - closed
   # push:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: main
+          ref: master
           fetch-tags: true
       - name: Bump version and get tag
         id: new_version


### PR DESCRIPTION
Update workflows to target proper default branch