### PR TITLE
feat: Install buildx and compose v2 plugins

### DIFF
--- a/vars/CentOS8.yml
+++ b/vars/CentOS8.yml
@@ -10,11 +10,15 @@ docker_install_community_edition: true
 
 docker_io_pkgs:
   - docker
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_ce_pkgs:
   - docker-ce
   - docker-ce-cli
   - containerd.io
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_py3_pkgs:
   - docker

--- a/vars/CentOS9.yml
+++ b/vars/CentOS9.yml
@@ -10,11 +10,15 @@ docker_install_community_edition: true
 
 docker_io_pkgs:
   - docker
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_ce_pkgs:
   - docker-ce
   - docker-ce-cli
   - containerd.io
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_py3_pkgs:
   - docker

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -11,11 +11,15 @@ docker_dependency_pkgs:
 docker_io_pkgs:
   - docker.io
   - containerd
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_ce_pkgs:
   - docker-ce
   - containerd.io
   - docker-ce-cli
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_py26_pkgs:
   - docker-py

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -12,11 +12,15 @@ docker_install_community_edition: true
 
 docker_io_pkgs:
   - docker
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_ce_pkgs:
   - docker-ce
   - docker-ce-cli
   - containerd.io
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_py26_pkgs:
   - docker-py

--- a/vars/RedHat9.yml
+++ b/vars/RedHat9.yml
@@ -10,11 +10,15 @@ docker_install_community_edition: true
 
 docker_io_pkgs:
   - docker
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_ce_pkgs:
   - docker-ce
   - docker-ce-cli
   - containerd.io
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_py3_pkgs:
   - docker

--- a/vars/Ubuntu18.yml
+++ b/vars/Ubuntu18.yml
@@ -7,6 +7,8 @@ docker_dependency_pkgs:
 docker_io_pkgs:
   - docker.io
   - containerd
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_nvidia_driver_dependencies:
   - gcc
@@ -39,6 +41,9 @@ docker_ce_pkgs:
   - docker-ce
   - containerd.io
   - docker-ce-cli
+  - docker-compose-plugin
+  - docker-buildx-plugin
+
 docker_py3_pkgs:
   - docker
   - docker-compose

--- a/vars/Ubuntu20.yml
+++ b/vars/Ubuntu20.yml
@@ -7,6 +7,8 @@ docker_dependency_pkgs:
 docker_io_pkgs:
   - docker.io
   - containerd
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_nvidia_driver_dependencies:
   - gcc
@@ -42,5 +44,7 @@ docker_ce_pkgs:
 docker_py3_pkgs:
   - docker
   - docker-compose
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_repo_url: https://download.docker.com/linux

--- a/vars/Ubuntu22.yml
+++ b/vars/Ubuntu22.yml
@@ -7,6 +7,8 @@ docker_dependency_pkgs:
 docker_io_pkgs:
   - docker.io
   - containerd
+  - docker-compose-plugin
+  - docker-buildx-plugin
 
 docker_nvidia_driver_dependencies:
   - gcc
@@ -39,6 +41,9 @@ docker_ce_pkgs:
   - docker-ce
   - containerd.io
   - docker-ce-cli
+  - docker-compose-plugin
+  - docker-buildx-plugin
+
 docker_py3_pkgs:
   - docker==6.1.3
   - docker-compose


### PR DESCRIPTION
`buildx` is the new recommended way to build packages
`compose v2` supports parallel image builds and more.

Instructions for installing compose v2:
https://docs.docker.com/compose/install/linux/
Instructions for installing buildx:
https://github.com/docker/buildx?tab=readme-ov-file#linux-packages