### PR TITLE
fix: Add python3-debian dependency

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,6 +6,8 @@ docker_dependency_pkgs:
   - python3-docker
   - python3-dockerpycreds
   - python3-dockerpty
+  - python3-debian
+
 docker_io_pkgs:
   - docker.io
   - containerd

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -6,6 +6,7 @@ docker_dependency_pkgs:
   - python3-docker
   - python3-dockerpycreds
   - python3-dockerpty
+  - python3-debian
 
 docker_io_pkgs:
   - docker.io

--- a/vars/Ubuntu22.yml
+++ b/vars/Ubuntu22.yml
@@ -6,6 +6,7 @@ docker_dependency_pkgs:
   - python3-docker
   - python3-dockerpycreds
   - python3-dockerpty
+  - python3-debian
 
 docker_io_pkgs:
   - docker.io


### PR DESCRIPTION
The `ansible.builtin.deb822_repository` module requires `python3-debian` package be installed.