### PR TITLE
fix: Pin docker python packages

### DIFF
--- a/vars/Ubuntu22.yml
+++ b/vars/Ubuntu22.yml
@@ -58,7 +58,7 @@ docker_nvidia_cuda_packages:
   - nvidia-cuda-toolkit
 
 docker_py3_pkgs:
-  - docker
-  - docker-compose
+  - docker==5.0.3
+  - docker-compose==1.29.2
 
 docker_repo_url: https://download.docker.com/linux


### PR DESCRIPTION
Pins docker python packages for 22.04