### PR TITLE
compose service update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -135,7 +135,17 @@ docker_compose_args: |-
     {%- endif -%}
     {%- if service.privileged | default(None) is not none -%}
       {%- set ns.service = ns.service | combine({
-        "privileged": service.privileged | default(false)
+        "privileged": service.privileged | default(omit)
+      }) -%}
+    {%- endif -%}
+    {%- if service.entrypoint | default(None) is not none -%}
+      {%- set ns.service = ns.service | combine({
+        "entrypoint": service.entrypoint | default(omit)
+      }) -%}
+    {%- endif -%}
+    {%- if service.depends_on | default(None) is not none -%}
+      {%- set ns.service = ns.service | combine({
+        "depends_on": service.depends_on | default(omit)
       }) -%}
     {%- endif -%}
     {%- set ns.service = ns.service | combine({

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,7 +150,6 @@ docker_compose_args: |-
     {%- endif -%}
     {%- set ns.service = ns.service | combine({
       "environment": ns.envs,
-      "runtime": service.runtime | default(omit),
       "volumes": ns.mounts,
       "devices": ns.devices
     }) -%}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,6 +128,11 @@ docker_compose_args: |-
         ] -%}
       {%- endfor -%}
     {%- endif -%}
+    {%- if service.network_mode | default(None) is not none -%}
+      {%- set ns.service = ns.service | combine({
+        "network_mode": service.network_mode | default(omit)
+      }) -%}
+    {%- endif -%}
     {%- if service.privileged | default(None) is not none -%}
       {%- set ns.service = ns.service | combine({
         "privileged": service.privileged | default(false)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,6 @@ docker_nvidia_transcode_patch_dir: /opt/nvidia
 #   mode: 774
 
 docker_compose_project_name:
-docker_compose_services:
 docker_compose_args: |-
   {%- set ns = namespace(services={}, service={}, ports=[], envs={}, mounts=[], devices=[], root_dir=undefined) -%}
   {%- for service_name, service in docker_compose_services.items() -%}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,9 @@ docker_compose_args: |-
         "/dev/dri/renderD128:/dev/dri/renderD128"
       ] -%}
       {%- set ns.service = ns.service | combine({
+        "runtime": "nvidia" if (service.runtime is undefined or service.runtime == "nvidia") else service.runtime | default(omit)
+      }) -%}
+      {%- set ns.service = ns.service | combine({
         "deploy": {
           "resources": {
             "reservations": {

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ docker_compose_project_name:
 docker_compose_args: |-
   {%- set ns = namespace(services={}, service={}, ports=[], envs={}, mounts=[], devices=[], root_dir=undefined) -%}
   {%- for service_name, service in docker_compose_services.items() -%}
-    {%- if service.root_dir | default(False) -%}
+    {%- if service.root_dir | default(None) is not none -%}
       {%- if service.root_dir | regex_search("^.*/$") is not none -%}
         {%- set ns.root_dir = service.root_dir -%}
       {%- else -%}


### PR DESCRIPTION
- remove docker_compose_services var that is used as registered var
- update root_dir condition
- nest runtime in gpu if condition - if gpu is true and runtime is undef. or nvidia, use nvidia runtime, else  override to user choice
- add block for network mode
- add blocks for privileged, entrpoint, depends_on
- moved runtime into gpu block
