### PR TITLE
fix: Setting these wrong will hide the cuda devices. So lets just let the toolkit figure it out

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,8 +89,6 @@ docker_compose_args: |-
         }
       }) -%}
       {%- set ns.envs = ns.envs | combine({
-        "CUDA_VISIBLE_DEVICES": "all",
-        "CUDA_VISIBLE_CAPABILITIES": "all" if service.gpu is boolean else (service.gpu.capabilities | string)  | default("all"),
         "NVIDIA_VISIBLE_DEVICES": "all",
         "NVIDIA_DRIVER_CAPABILITIES": "all" if service.gpu is boolean else (service.gpu.capabilities | string) | default("all")
       }) -%}


### PR DESCRIPTION
If the CUDA_VISIBLE_DEVICES is set incorrectly, they will not be visible. Omitting these CUDA envs, the toolkit will figure it out